### PR TITLE
Fix Folder path Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip install submodules/diff-gaussian-rasterization
 pip install submodules/simple-knn/
 
 # tetra-nerf for Marching Tetrahedra
-cd submodules/tetra-triangulation
+cd submodules/tetra_triangulation
 conda install cmake
 conda install conda-forge::gmp
 conda install conda-forge::cgal


### PR DESCRIPTION
The current right path:
<img width="288" alt="image" src="https://github.com/user-attachments/assets/acd85fd6-2023-4a17-8918-a553a17687bc" />

While in readme:
<img width="582" alt="image" src="https://github.com/user-attachments/assets/781aff6f-6901-418e-8674-0d11f30b31be" />

Can help people copy paste smoother

